### PR TITLE
Handle rotations by pi

### DIFF
--- a/pylie/so3.py
+++ b/pylie/so3.py
@@ -100,12 +100,17 @@ class SO3:
         """
         R = self.matrix
 
-        theta = np.arccos(np.clip(0.5 * (R.trace() - 1), -1, 1))
+        x = np.clip(0.5 * (R.trace() - 1), -1, 1)
 
-        if theta < 1e-10:
+        if x > 1 - 1e-10:
             theta = 0
             u_vec = np.array([[0, 0, 0]]).T
+        elif x < -(1 - 1e-10):
+            theta = np.pi
+            u_vec = SO3.vee(R - R.T)
+            u_vec /= np.linalg.norm(u_vec)
         else:
+            theta = np.arccos(x)
             u_vec = SO3.vee(R - R.T) / (2 * np.sin(theta))
 
         if split_angle_axis:

--- a/tests/test_so3.py
+++ b/tests/test_so3.py
@@ -436,3 +436,21 @@ def test_string_representation_is_matrix():
 
     # Should be the same as the string representation of the matrix.
     np.testing.assert_equal(str(X), str(X.matrix))
+
+
+def test_log_for_pi():
+    theta = np.pi - 1e-8
+    np.random.seed(42)
+
+    for i in range(100):
+        u = np.random.rand(3)[None].T
+        u /= np.linalg.norm(u)
+        X = SO3.Exp(theta*u)
+
+        theta_, u_ = X.Log(split_angle_axis=True)
+        np.testing.assert_almost_equal(theta_, theta)
+        np.testing.assert_almost_equal(u_, u)
+
+        theta_u = X.Log()
+        np.testing.assert_almost_equal(np.linalg.norm(theta_u), theta)
+        np.testing.assert_almost_equal(theta_u/np.linalg.norm(theta_u), u)


### PR DESCRIPTION
Hello there!

I was getting some weird results for `SO3.Log()` on angle-axis rotations with $\theta \approx \pi$.

The issue is essentially the same as for $\theta \approx 0$, but in this case we also need to estimate $\mathbf{u}$.

Not sure if the proposed fix is the way to do it, but it passes the test at least!